### PR TITLE
Supersede the wwt-documentation repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,8 +4,6 @@ permalink: "/code-of-conduct/"
 nav_order: 3
 ---
 
-<!-- TODO: this duplicates what's in `wwt-documentation` -->
-
 # AAS WorldWide Telescope Code of Conduct
 
 The AAS WorldWide Telescope is dedicated to providing a welcoming and

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 ---
-title: AAS WorldWide Telescope Code of Conduct
+title: WWT Code of Conduct
 permalink: "/code-of-conduct/"
 nav_order: 3
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ major sections of this guide:
 
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
-[coc]: https://worldwidetelescope.github.io/wwt-documentation/code-of-conduct/
+[coc]: ./CODE_OF_CONDUCT.md
 
 
 ## Bug Reports
@@ -79,10 +79,9 @@ Please make pull requests against the `master` branch.
 [writing-documentation]: #writing-documentation
 
 Documentation improvements are very welcome. The WWT GitHub organization
-includes many standalone repositories for various guidebook documents, as
-enumerated at the
-[WWT Documentation Hub](https://worldwidetelescope.github.io/wwt-documentat/).
-Documentation pull requests function in the same way as other pull requests.
+includes many standalone repositories for various guidebook documents that are
+enumerated on [the Contributor Hub main page](./index.md). Documentation pull
+requests function in the same way as other pull requests.
 
 Our documentation is written in
 [Markdown](https://en.wikipedia.org/wiki/Markdown) (with the file extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,13 @@ use it exactly:
 
     <steps to trigger the bug>
 
-    I expected to see this happen: <explanation>
+    I expected to see this happen:
 
-    Instead, this happened: <explanation>
+    <description>
+
+    Instead, this happened:
+
+    <description>
 
 All three components are important: what you did, what you expected, what
 happened instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: The AAS WorldWide Telescope Contributors’ Guide
+title: WWT Contributors’ Guide
 permalink: "/contributing/"
 nav_order: 2
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -12,4 +12,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
-  - CODE_OF_CONDUCT.md # canonical version is in `wwt-documentation`
+

--- a/index.md
+++ b/index.md
@@ -23,12 +23,36 @@ organization of professional astronomers in North America.
 
 ## Quick Links
 
-- [Contributing to WWT](./CONTRIBUTING.md).
-- [The main WWT website](http://www.worldwidetelescope.org/)!
-- [The WWT GitHub organization](https://github.com/WorldWideTelescope).
-- [The WWT Documentation Hub](https://worldwidetelescope.github.io/wwt-documentation),
-  which includes ample developer documentation.
-- [The pywwt documentation](https://pywwt.readthedocs.io/en/stable/) on
-  *readthedocs.io*.
-- [WWT project Code of Conduct](https://worldwidetelescope.github.io/wwt-documentation/code-of-conduct/).
-- [The Git repository for this website](https://github.com/WorldWideTelescope/worldwidetelescope.github.io/).
+- [Contributing to WWT](./CONTRIBUTING.md)
+- [The main WWT website!](http://www.worldwidetelescope.org/)
+- [The WWT GitHub organization](https://github.com/WorldWideTelescope)
+- [WWT project Code of Conduct](./CODE_OF_CONDUCT.md)
+- [The Git repository for this website](https://github.com/WorldWideTelescope/worldwidetelescope.github.io/)
+
+## Documentation
+
+| Document | Source Repository |
+|-- | -- |
+| [User Manual](https://worldwidetelescope.gitbook.io/worldwide-telescope-user-manual/) | [worldwide-telescope-manual](https://github.com/WorldWideTelescope/worldwide-telescope-manual) |
+| [pywwt Manual and API Reference](https://pywwt.readthedocs.io/) | [pywwt](https://github.com/WorldWideTelescope/pywwt) |
+| [Contributors’ Guide](./CONTRIBUTING.md) | [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io) |
+| [HTML5 Scripting Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-web-control-script-reference/) | [worldwide-telescope-web-control-script-reference](https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference) |
+| [Layer Control API Documentation](https://worldwidetelescope.gitbook.io/worldwide-telescope-layer-control-api/) | [WorldWide-Telescope-Layer-Control-API](https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API) |
+| [Projection Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-projection-reference/) | [worldwide-telescope-projection-reference](https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference) |
+| [Data Tools Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-data-tools-guide/) | [worldwide-telescope-data-tools-guide](https://github.com/WorldWideTelescope/worldwide-telescope-data-tools-guide) |
+| [Data Files Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-data-files-reference/) | [worldwide-telescope-data-files-reference](https://github.com/WorldWideTelescope/worldwide-telescope-data-files-reference) |
+| [Pyramid SDK Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-pyramid-sdk-reference/) | [worldwide-telescope-pyramid-sdk](https://github.com/WorldWideTelescope/worldwide-telescope-pyramid-sdk) |
+| [Advanced Guides](https://worldwidetelescope.gitbook.io/worldwide-telescope-advanced-guides/) | [worldwide-telescope-advanced-guides](https://github.com/WorldWideTelescope/worldwide-telescope-advanced-guides) |
+| [WWT Planetarium Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-planetarium/) | [worldwide-telescope-planetarium](https://github.com/WorldWideTelescope/worldwide-telescope-planetarium) |
+| [Multi-Channel Dome Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-multi-channel-dome-setup/) | [worldwide-telescope-multi-channel-dome-setup](https://github.com/WorldWideTelescope/worldwide-telescope-multi-channel-dome-setup) |
+| [Importing NASA SPICE Kernel Data into WorldWide Telescope](https://astrodavid.gitbook.io/importing-spice-kernel-data-to-worldwide-telescop/) | none? |
+| [Using WorldWide Telescope to produce Science Shorts](https://doctorspaceman.gitbook.io/using-worldwide-telescope-to-produce-science-shor/) | none? |
+| [Project Code of Conduct](./CODE_OF_CONDUCT.md) | [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io) |
+
+## Get Involved
+
+We would love your help in making WWT better! Please read our
+[Contributors’ Guide](./CONTRIBUTING.md) to get started. The source code for
+this site lives at the
+[worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io)
+repository.

--- a/index.md
+++ b/index.md
@@ -1,3 +1,8 @@
+---
+title: WWT Contributor Hub
+nav_order: 1
+---
+
 <!-- See README.md for how to preview this file when making edits -->
 
 # Welcome to the AAS WorldWide Telescope Contributor Hub!

--- a/index.md
+++ b/index.md
@@ -52,7 +52,8 @@ organization of professional astronomers in North America.
 ## Get Involved
 
 We would love your help in making WWT better! Please read our
-[Contributors’ Guide](./CONTRIBUTING.md) to get started. The source code for
+[Contributors’ Guide](./CONTRIBUTING.md) and
+[Code of Conduct](./CODE_OF_CONDUCT.md) to get started. The source code for
 this site lives at the
 [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io)
 repository.


### PR DESCRIPTION
As things have iterated, that repo isn't really doing anything useful and it's nicer to centralize everything in this one.