### PR TITLE
index.md: update for less-redundant GitBook links

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,18 +33,18 @@ organization of professional astronomers in North America.
 
 | Document | Source Repository |
 |-- | -- |
-| [User Manual](https://worldwidetelescope.gitbook.io/worldwide-telescope-user-manual/) | [worldwide-telescope-manual](https://github.com/WorldWideTelescope/worldwide-telescope-manual) |
+| [User Manual](https://worldwidetelescope.gitbook.io/user-manual/) | [worldwide-telescope-manual](https://github.com/WorldWideTelescope/worldwide-telescope-manual) |
 | [pywwt Manual and API Reference](https://pywwt.readthedocs.io/) | [pywwt](https://github.com/WorldWideTelescope/pywwt) |
 | [Contributors’ Guide](./CONTRIBUTING.md) | [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io) |
-| [HTML5 Scripting Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-web-control-script-reference/) | [worldwide-telescope-web-control-script-reference](https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference) |
-| [Layer Control API Documentation](https://worldwidetelescope.gitbook.io/worldwide-telescope-layer-control-api/) | [WorldWide-Telescope-Layer-Control-API](https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API) |
-| [Projection Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-projection-reference/) | [worldwide-telescope-projection-reference](https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference) |
-| [Data Tools Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-data-tools-guide/) | [worldwide-telescope-data-tools-guide](https://github.com/WorldWideTelescope/worldwide-telescope-data-tools-guide) |
-| [Data Files Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-data-files-reference/) | [worldwide-telescope-data-files-reference](https://github.com/WorldWideTelescope/worldwide-telescope-data-files-reference) |
-| [Pyramid SDK Reference](https://worldwidetelescope.gitbook.io/worldwide-telescope-pyramid-sdk-reference/) | [worldwide-telescope-pyramid-sdk](https://github.com/WorldWideTelescope/worldwide-telescope-pyramid-sdk) |
-| [Advanced Guides](https://worldwidetelescope.gitbook.io/worldwide-telescope-advanced-guides/) | [worldwide-telescope-advanced-guides](https://github.com/WorldWideTelescope/worldwide-telescope-advanced-guides) |
-| [WWT Planetarium Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-planetarium/) | [worldwide-telescope-planetarium](https://github.com/WorldWideTelescope/worldwide-telescope-planetarium) |
-| [Multi-Channel Dome Guide](https://worldwidetelescope.gitbook.io/worldwide-telescope-multi-channel-dome-setup/) | [worldwide-telescope-multi-channel-dome-setup](https://github.com/WorldWideTelescope/worldwide-telescope-multi-channel-dome-setup) |
+| [HTML5 Scripting Reference](https://worldwidetelescope.gitbook.io/html5-control-reference/) | [worldwide-telescope-web-control-script-reference](https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference) |
+| [Layer Control API Reference](https://worldwidetelescope.gitbook.io/layer-control-reference/) | [WorldWide-Telescope-Layer-Control-API](https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API) |
+| [Projection Reference](https://worldwidetelescope.gitbook.io/projection-reference/) | [worldwide-telescope-projection-reference](https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference) |
+| [Data Tools Guide](https://worldwidetelescope.gitbook.io/data-tools-guide/) | [worldwide-telescope-data-tools-guide](https://github.com/WorldWideTelescope/worldwide-telescope-data-tools-guide) |
+| [Data Files Reference](https://worldwidetelescope.gitbook.io/data-files-reference/) | [worldwide-telescope-data-files-reference](https://github.com/WorldWideTelescope/worldwide-telescope-data-files-reference) |
+| [Pyramid SDK Reference](https://worldwidetelescope.gitbook.io/pyramid-sdk-reference/) | [worldwide-telescope-pyramid-sdk](https://github.com/WorldWideTelescope/worldwide-telescope-pyramid-sdk) |
+| [Advanced Guides](https://worldwidetelescope.gitbook.io/advanced-guides/) | [worldwide-telescope-advanced-guides](https://github.com/WorldWideTelescope/worldwide-telescope-advanced-guides) |
+| [WWT Planetarium Guide](https://worldwidetelescope.gitbook.io/planetarium-guide/) | [worldwide-telescope-planetarium](https://github.com/WorldWideTelescope/worldwide-telescope-planetarium) |
+| [Multi-Channel Dome Guide](https://worldwidetelescope.gitbook.io/multi-channel-dome-setup/) | [worldwide-telescope-multi-channel-dome-setup](https://github.com/WorldWideTelescope/worldwide-telescope-multi-channel-dome-setup) |
 | [Importing NASA SPICE Kernel Data into WorldWide Telescope](https://astrodavid.gitbook.io/importing-spice-kernel-data-to-worldwide-telescop/) | none? |
 | [Using WorldWide Telescope to produce Science Shorts](https://doctorspaceman.gitbook.io/using-worldwide-telescope-to-produce-science-shor/) | none? |
 | [Project Code of Conduct](./CODE_OF_CONDUCT.md) | [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io) |


### PR DESCRIPTION
We've upgraded to non-legacy GitBook and I've gone and made the URLs shorter. (You can do that in the "advanced" settings for each book.)