### PR TITLE
events: add a "What is WWT?" item with the new YouTube video

### DIFF
--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -12,9 +12,44 @@
   src: url("/fonts/39762C_2_0.eot?#iefix") format("embedded-opentype"), url("/fonts/39762C_2_0.woff2") format("woff2"), url("/fonts/39762C_2_0.woff") format("woff"), url("/fonts/39762C_2_0.ttf") format("truetype");
 }
 
-.callout {
+
+/* <details> elements need some fixup */
+
+details {
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
   background-color: #eef;
-  padding: 0.5rem 1rem 0rem 1rem;
   font-size: 110%;
   border-radius: 6px;
+}
+
+details > summary {
+  display: list-item;  /* justthedocs css overrides this, which is needed to get the disclosure triangle */
+  cursor: pointer;
+  font-size: 110%;
+  font-weight: bold;
+}
+
+details[open] > summary {
+  margin-bottom: 0.5rem;
+}
+
+
+/* YouTube video embeds need help to keep working on mobile - https://flaviocopes.com/responsive-youtube-videos/ */
+
+div.responsive-16x9-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+div.responsive-16x9-container > iframe {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }

--- a/events/index.md
+++ b/events/index.md
@@ -3,26 +3,51 @@ title: WWT Events
 nav_order: 4
 ---
 
+<!-- N.B.: our physical swag items direct people to the URL of this page, so
+ it should be awesome and useful for people who have no idea what WWT is! -->
+
 # AAS WorldWide Telescope: Current Events
-
-<div class="callout" markdown="1">
-
-**Click the links for information and resources regarding these upcoming WWT
-  events:**
-
-- [WWT @ AAS235] (Honolulu, HI, USA; 2020 January 4–8)
-
-[WWT @ AAS235]: https://wwt-forum.org/t/researcher-workshop-wwt-aas235-honolulu-usa-2020-january-5/71
-
-Whether you’re just curious about what’s going on, or planning to attend
-something and looking for information, the links above have what you need.
-
-</div>
 
 There’s no better way to build up the [AAS](https://aas.org/)
 [WorldWide Telescope](/) community than getting together in person! We strive
-to maintain a regular schedule of events, with upcoming ones highlighted
-above. If you’re not able to make it to any in-person events, try checking out
+to maintain a regular schedule of events — here’s what’s current:
+
+<details markdown="1">
+  <summary>WWT @ AAS235 (Honolulu, HI, USA; 2020 January 4–8)</summary>
+
+  The WWT team will be busy during the [AAS235] meeting in Honolulu, Hawai'i!
+
+  - **Saturday, Jan 4, time TBC**: WWT in Education tutorial (location TBC)
+  - **Sunday, Jan 5, 1–2 PM**: [Researcher Workshop] (rm 307B) — *registration required*
+  - **Sunday, Jan 5, 5–6 PM**: AAS Publishing Reception with refreshments (AAS Booth in Exhibit Hall)
+  - **Tuesday, Jan 7, 12–1:30 PM**: What’s New in AAS Publishing (rm 301B)
+  - **Tuesday, Jan 7, 5–6:30 PM**: NASA’s Universe of Learning Data
+    Visualization splinter session (location TBC)
+  - **Wednesday, Jan 8, all day**: WWT @ Hack Together Day (rm 323C)
+  - **Wednesday, Jan 8, 2–3 PM**: AAS Publications Committee open forum (location TBC)
+
+  [Researcher Workshop]: https://wwt-forum.org/t/researcher-workshop-wwt-aas235-honolulu-usa-2020-january-5/71
+  [AAS235]: https://aas.org/meetings/aas235
+</details>
+
+<details class="videobox" markdown="1">
+  <summary>What is the AAS WorldWide Telescope?</summary>
+
+  WWT is a free and open-source tool for showcasing astronomical data and
+  knowledge, brought to you by the
+  [American Astronomical Society](https://aas.org/) (AAS). Use WWT online at
+  [worldwidetelescope.org](http://worldwidetelescope.org).
+
+  <div class="responsive-16x9-container">
+    <iframe src="https://www.youtube-nocookie.com/embed/CD_W6wJp26E"
+            frameborder="0"
+            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen>
+    </iframe>
+  </div>
+</details>
+
+If you’re not able to make it to any in-person events, try checking out
 [our YouTube channel] or [our discussion forum], and sign up for
 [our announcements mailing list] to stay in touch!
 


### PR DESCRIPTION
After trying a few approaches I think the best option is to go with a `<details>` disclosure widget. If we present upcoming events in the same way, I think the landing page gets a nice logical flow with a clear course of action for visitors.