### PR TITLE
Add AAS236, update here and there

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,7 @@ requests function in the same way as other pull requests.
 
 Our documentation is written in
 [Markdown](https://en.wikipedia.org/wiki/Markdown) (with the file extension
-`.md`) and rendered with [Gitbook](https://www.gitbook.com/). The
-documentation source structure is itself documented in the
-[WWT GitBook Markdown Format Specification](https://worldwidetelescope.gitbook.io/miscellaneous/documents/gitbook-spec).
+`.md`) and rendered with [Zola](https://getzola.org/).
 
 
 ## The Fine Print to Contributing

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: WWT Contributor Hub
 url: "https://worldwidetelescope.github.io"
 email: wwt@aas.org
 description: >-
-  The hub for resources related to contributions to the AAS WorldWide
+  The hub for people who want to contribute to the AAS WorldWide
   Telescope project.
 twitter_username: wwtelescope
 github_username: WorldWideTelescope
@@ -14,7 +14,7 @@ aux_links:
   "Source on GitHub!":
     - "//github.com/WorldWideTelescope/worldwidetelescope.github.io/"
 
-footer_content: "Copyright 2019 the .NET Foundation. The AAS WorldWide Telescope is brought to you by the American Astronomical Society <a href=\"/#acknowledgments\">and other supporters</a>."
+footer_content: "Copyright 2019-2020 the .NET Foundation. The AAS WorldWide Telescope is brought to you by the American Astronomical Society <a href=\"/#acknowledgments\">and other supporters</a>."
 
 ga_tracking: UA-107473046-4
 

--- a/events/index.md
+++ b/events/index.md
@@ -22,8 +22,8 @@ to maintain a regular schedule of events — here’s what’s current:
 
   WWT is a free and open-source tool for showcasing astronomical data and
   knowledge, brought to you by the
-  [American Astronomical Society](https://aas.org/) (AAS). Use WWT online at
-  [worldwidetelescope.org](http://worldwidetelescope.org).
+  [American Astronomical Society](https://aas.org/) (AAS). Find out more at
+  [worldwidetelescope.org](http://worldwidetelescope.org/home/).
 
   <div class="responsive-16x9-container">
     <iframe src="https://www.youtube-nocookie.com/embed/CD_W6wJp26E"
@@ -48,6 +48,7 @@ If you’re not able to make it to any in-person events, try checking out
 Here we archive some of the materials associated with some previous WWT
 events — completeness not guaranteed.
 
+- WWT @ AAS236 (virtual; 2020 June 1)
 - [WWT @ AAS235] (Honolulu, HI, USA; 2020 January 5–9)
 - [WWT @ Petabytes to Science 3] (Boston, MA, USA; 2019 November 6–8)
 - [WWT @ ADASS29] (Groningen, Netherlands; 2019 October 6–10)

--- a/index.md
+++ b/index.md
@@ -32,31 +32,24 @@ America.
 
 - [WWT discussion forum]
 - [WWT Contributors’ Guide]
-- [The main WWT website!](http://www.worldwidetelescope.org/)
-- [The WWT GitHub organization](https://github.com/WorldWideTelescope)
+- [WWT user website]
+- [WWT Documentation Hub]
 - [WWT Code of Conduct]
 - [Sign up for the WWT newsletter](https://bit.ly/wwt-signup)
 
 [WWT discussion forum]: https://wwt-forum.org/
+[WWT Contributors’ Guide]: ./CONTRIBUTING.md
+[WWT user website]: https://www.worldwidetelescope.org/home/
+[WWT Documentation Hub]: https://docs.worldwidetelescope.org/
+[WWT Code of Conduct]: ./CODE_OF_CONDUCT.md
 
+For developers:
 
-## Example Code
+- [WWT GitHub organization]
+- [WWT Azure DevOps organization]
 
-| Example Collection | Source Repository |
-|-- | -- |
-| [WWT WebGl Engine Examples] | [wwt-web-examples] |
-| [“Starfield” art installation] | [wwt-kinect-swing-control] |
-
-[WWT WebGl Engine Examples]: http://webhosted.wwt-forum.org/webengine-examples/
-[“Starfield” art installation]: https://muda.co/starfield/
-
-[wwt-web-examples]: https://github.com/WorldWideTelescope/wwt-web-examples/
-[wwt-kinect-swing-control]: https://github.com/WorldWideTelescope/wwt-kinect-swing-control/
-
-At the moment, we must host the Web examples on a separate domain that can
-serve them over unsecured HTTP. This is because the core WWT web services are
-not HTTPS-enabled, and so cannot be embedded inside HTTPS web pages such as
-stock GitHub Pages sites. We are working to fix this!
+[WWT GitHub organization]: https://github.com/WorldWideTelescope
+[WWT Azure DevOps organization]: https://dev.azure.com/aasworldwidetelescope/
 
 
 ## Stay in Touch!
@@ -74,78 +67,8 @@ happen:
 
 ## Documentation
 
-### Primary documents
-
-| Document | Source Repository |
-|-- | -- |
-| [WWT Contributors’ Guide] | [worldwidetelescope.github.io] |
-| [WWT Code of Conduct] | [worldwidetelescope.github.io] |
-| [pywwt Manual and API Reference] | [pywwt] |
-| [WebGL Engine Reference] | [worldwide-telescope-webgl-sdk-reference] |
-| [Setting Up a Windows VM for WWT Development] | [wwtdoc-misc] |
-| [GitBook Markdown Format Specification] | [wwtdoc-misc] |
-
-[WWT Contributors’ Guide]: ./CONTRIBUTING.md
-[WWT Code of Conduct]: ./CODE_OF_CONDUCT.md
-[pywwt Manual and API Reference]: https://pywwt.readthedocs.io/
-[WebGL Engine Reference]: https://worldwidetelescope.gitbook.io/webgl-engine-reference/
-[Setting Up a Windows VM for WWT Development]: https://worldwidetelescope.gitbook.io/miscellaneous/documents/windows-vm-setup
-[GitBook Markdown Format Specification]: https://worldwidetelescope.gitbook.io/miscellaneous/documents/gitbook-spec
-
-[worldwidetelescope.github.io]: https://github.com/WorldWideTelescope/worldwidetelescope.github.io
-[pywwt]: https://github.com/WorldWideTelescope/pywwt
-[worldwide-telescope-webgl-sdk-reference]: https://github.com/WorldWideTelescope/worldwide-telescope-webgl-sdk-reference
-[wwtdoc-misc]: https://github.com/WorldWideTelescope/wwtdoc-misc
-
-### Best-effort documents
-
-Unfortunately, the following documents are not necessarily up-to-date, and may
-not render correctly after
-[the GitBook upgrade](https://docs.gitbook.com/v2-changes). Caveat emptor. We
-aspire for all of these to be fresh, accurate, and readable, but contributor
-bandwidth is limited. Contributions are more than welcome! So are GitHub
-issues naming any particular sections that you would like one of the core WWT
-contributors to review.
-
-| Document | Source Repository |
-|-- | -- |
-| [User Manual] | [worldwide-telescope-manual] |
-| [Layer Control API Reference] | [WorldWide-Telescope-Layer-Control-API] |
-| [Projection Reference] | [worldwide-telescope-projection-reference] |
-| [Data Tools Guide] | [worldwide-telescope-data-tools-guide] |
-| [Data Files Reference] | [worldwide-telescope-data-files-reference] |
-| [Pyramid SDK Reference] | [worldwide-telescope-pyramid-sdk] |
-| [Advanced Guides] | [worldwide-telescope-advanced-guides] |
-| [(Deprecated) HTML5 Scripting Reference] | [worldwide-telescope-web-control-script-reference] |
-| [WWT Planetarium Guide] | [worldwide-telescope-planetarium] |
-| [Multi-Channel Dome Guide] | [worldwide-telescope-multi-channel-dome-setup] |
-| [Importing NASA SPICE Kernel Data into WorldWide Telescope] | none? |
-| [Using WorldWide Telescope to produce Science Shorts] | none? |
-
-[User Manual]: https://worldwidetelescope.gitbook.io/user-manual/
-[Layer Control API Reference]: https://worldwidetelescope.gitbook.io/layer-control-reference/
-[Projection Reference]: https://worldwidetelescope.gitbook.io/projection-reference/
-[Data Tools Guide]: https://worldwidetelescope.gitbook.io/data-tools-guide/
-[Data Files Reference]: https://worldwidetelescope.gitbook.io/data-files-reference/
-[Pyramid SDK Reference]: https://worldwidetelescope.gitbook.io/pyramid-sdk-reference/
-[Advanced Guides]: https://worldwidetelescope.gitbook.io/advanced-guides/
-[(Deprecated) HTML5 Scripting Reference]: https://worldwidetelescope.gitbook.io/html5-control-reference/
-[WWT Planetarium Guide]: https://worldwidetelescope.gitbook.io/planetarium-guide/
-[Multi-Channel Dome Guide]: https://worldwidetelescope.gitbook.io/multi-channel-dome-setup/
-[Importing NASA SPICE Kernel Data into WorldWide Telescope]: https://astrodavid.gitbook.io/importing-spice-kernel-data-to-worldwide-telescop/
-[Using WorldWide Telescope to produce Science Shorts]: https://doctorspaceman.gitbook.io/using-worldwide-telescope-to-produce-science-shor/
-
-[worldwide-telescope-manual]: https://github.com/WorldWideTelescope/worldwide-telescope-manual
-[WorldWide-Telescope-Layer-Control-API]: https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API
-[worldwide-telescope-projection-reference]: https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference
-[worldwide-telescope-data-tools-guide]: https://github.com/WorldWideTelescope/worldwide-telescope-data-tools-guide
-[worldwide-telescope-data-files-reference]: https://github.com/WorldWideTelescope/worldwide-telescope-data-files-reference
-[worldwide-telescope-pyramid-sdk]: https://github.com/WorldWideTelescope/worldwide-telescope-pyramid-sdk
-[worldwide-telescope-advanced-guides]: https://github.com/WorldWideTelescope/worldwide-telescope-advanced-guides
-[worldwide-telescope-web-control-script-reference]: https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference
-[worldwide-telescope-planetarium]: https://github.com/WorldWideTelescope/worldwide-telescope-planetarium
-[worldwide-telescope-multi-channel-dome-setup]: https://github.com/WorldWideTelescope/worldwide-telescope-multi-channel-dome-setup
-[worldwidetelescope.github.io]: https://github.com/WorldWideTelescope/worldwidetelescope.github.io
+WWT documentation is now organized on the [WWT Documentation Hub],
+<https://docs.worldwidetelescope.org/>.
 
 
 ## Get Involved
@@ -154,16 +77,19 @@ We would love your help in making WWT better! Please read the
 [WWT Contributors’ Guide] and [WWT Code of Conduct] to get started. The source
 code for this site lives at the [worldwidetelescope.github.io] repository.
 
+[worldwidetelescope.github.io]: https://github.com/WorldWideTelescope/worldwidetelescope.github.io
+
 
 ## Acknowledgments
 
 The AAS WorldWide Telescope system is a [.NET Foundation] project. Work on WWT
 has been supported by the [American Astronomical Society] (AAS), the US
-[National Science Foundation] (grants [1550701] and [1642446]), the [Gordon
+[National Science Foundation] (grants [1550701], [1642446], [2004840]), the [Gordon
 and Betty Moore Foundation], and [Microsoft].
 
 [National Science Foundation]: https://www.nsf.gov/
 [1550701]: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1550701
 [1642446]: https://www.nsf.gov/awardsearch/showAward?AWD_ID=1642446
+[2004840]: https://www.nsf.gov/awardsearch/showAward?AWD_ID=2004840
 [Gordon and Betty Moore Foundation]: https://www.moore.org/
 [Microsoft]: https://www.microsoft.com/


### PR DESCRIPTION
This website has stagnated and its purpose is a bit less clear now that we can actually update the main worldwidetelescope.org and its subdomains. We'll need to ponder what to do with this. But in the meantime, polish it up a bit.