### PR TITLE
Update dep versions for ADASS tutorial

### DIFF
--- a/events/2022/adass32-tutorial/wwtviz.yml
+++ b/events/2022/adass32-tutorial/wwtviz.yml
@@ -9,6 +9,8 @@ dependencies:
   - nodejs=18.10.0
   - python=3.10.6
   - pywwt=0.16.0
+  - reproject=0.9
+  - shapely=1.8.4
   - toasty=0.18.1
   - wwt_data_formats=0.16.0
   - wwt_jupyterlab_extension=1.4.0

--- a/events/2022/adass32-tutorial/wwtviz.yml
+++ b/events/2022/adass32-tutorial/wwtviz.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - astropy=5.1
   - astropy-healpix=0.7
+  - astroquery=0.4.6
   - jupyterlab=3.4.8
   - nodejs=18.10.0
   - python=3.10.6

--- a/events/2022/adass32-tutorial/wwtviz.yml
+++ b/events/2022/adass32-tutorial/wwtviz.yml
@@ -7,7 +7,7 @@ dependencies:
   - jupyterlab=3.4.8
   - nodejs=18.10.0
   - python=3.10.6
-  - pywwt=0.15.2
+  - pywwt=0.16.0
   - toasty=0.18.1
   - wwt_data_formats=0.16.0
   - wwt_jupyterlab_extension=1.4.0


### PR DESCRIPTION
In particular, we need pywwt 0.16 to work with the latest Toasty.